### PR TITLE
Fix "proyect" typo in footer, GitHub caps

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
 	<!-- The credits -->
 	<div id="credits">
 		<p>Created by <a href="http://github.com/fixmycode">Pablo Albornoz</a></p>
-		<p>Help improve this proyect on <a href="http://github.com/fixmycode/IPFCalc/">Github</a></p>
+		<p>Help improve this project on <a href="http://github.com/fixmycode/IPFCalc/">GitHub</a></p>
 		<p>Learn more about <a href="http://en.wikipedia.org/wiki/IPv4#Fragmentation_and_reassembly">IPv4 fragmentation</a></p>
 	</div>
 	<!-- The scripts -->


### PR DESCRIPTION
Hello there! I saw this IP Fragmentation Calculator project because of a networking class I'm in. 
I noticed there was a typo in the footer. "Project" was misspelled as "proyect." Also, GitHub was formatted as "Github."

Thanks for making this project; it's pretty cool!